### PR TITLE
Test  add tests for conjured items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A small inn with a prime location and some bad code.",
   "scripts": {
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "lint": "eslint ./ --ignore-path .gitignore"
   },
   "repository": {

--- a/src/gilded_rose.js
+++ b/src/gilded_rose.js
@@ -29,7 +29,7 @@ export function updateQuality(items) {
           items[i].quality = items[i].quality - 1
         }
       }
-    } else {
+    } else { // if the name is brie or bspasses or sulfuras
       if (items[i].quality < 50) {
         items[i].quality = items[i].quality + 1
         if (items[i].name == 'Backstage passes to a TAFKAL80ETC concert') {
@@ -68,3 +68,18 @@ export function updateQuality(items) {
     }
   }
 }
+
+const items = [
+  // new Item('+5 Dexterity Vest', 10, 20),
+  new Item('Haunted Shoe', -2, 10),
+  // new Item('Aged Brie', 2, 0),
+  // new Item('Elixir of the Mongoose', 5, 7),
+  // new Item('Sulfuras, Hand of Ragnaros', 0, 80),
+  // new Item('Backstage passes to a TAFKAL80ETC concert', -1, 32),
+  // new Item('Backstage passes to a TAFKAL80ETC concert', 10, 32),
+  // new Item('Conjured Mana Cake', 3, 6),
+];
+
+updateQuality(items);
+
+console.log(items);

--- a/src/gilded_rose.js
+++ b/src/gilded_rose.js
@@ -23,6 +23,16 @@ updateQuality(items);
 */
 export function updateQuality(items) {
   for (var i = 0; i < items.length; i++) {
+      if (items[i].name.startsWith('Conjured')) {
+        if (items[i].quality > 2) {
+          items[i].quality = items[i].quality - 2;
+        }
+        else {
+          items[i].quality = 0;
+        }
+        items[i].sell_in = items[i].sell_in - 1;
+        break;
+      }
     if (items[i].name != 'Aged Brie' && items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
       if (items[i].quality > 0) {
         if (items[i].name != 'Sulfuras, Hand of Ragnaros') {
@@ -69,17 +79,17 @@ export function updateQuality(items) {
   }
 }
 
-const items = [
-  // new Item('+5 Dexterity Vest', 10, 20),
-  new Item('Haunted Shoe', -2, 10),
-  // new Item('Aged Brie', 2, 0),
-  // new Item('Elixir of the Mongoose', 5, 7),
-  // new Item('Sulfuras, Hand of Ragnaros', 0, 80),
-  // new Item('Backstage passes to a TAFKAL80ETC concert', -1, 32),
-  // new Item('Backstage passes to a TAFKAL80ETC concert', 10, 32),
-  // new Item('Conjured Mana Cake', 3, 6),
-];
+// const items = [
+//   // new Item('+5 Dexterity Vest', 10, 20),
+//   new Item('Haunted Shoe', -2, 10),
+//   // new Item('Aged Brie', 2, 0),
+//   // new Item('Elixir of the Mongoose', 5, 7),
+//   // new Item('Sulfuras, Hand of Ragnaros', 0, 80),
+//   // new Item('Backstage passes to a TAFKAL80ETC concert', -1, 32),
+//   // new Item('Backstage passes to a TAFKAL80ETC concert', 10, 32),
+//   // new Item('Conjured Mana Cake', 3, 6),
+// ];
 
-updateQuality(items);
+// updateQuality(items);
 
-console.log(items);
+// console.log(items);

--- a/src/gilded_rose.spec.js
+++ b/src/gilded_rose.spec.js
@@ -48,6 +48,28 @@ describe('updating of sulfuras', () => {
 
 });
 
+describe('updating of conjured items', () => {
+  const conjuredItem = new Item('Conjured Mana Cake', 3, 6);
+
+  afterEach(() => {
+    // updates the quality and sell_in back to original quantities
+    conjuredItem.sell_in = 3;
+    conjuredItem.quality = 6;
+  });
+
+  it('decreases the quality of the item by 2', () => {
+    updateQuality([conjuredItem]);
+    expect(conjuredItem.quality).toBe(4);
+  });
+
+  it('does not decrease the quality of the item to a negative number', () => {
+    conjuredItem.quality = 0;
+    updateQuality([conjuredItem]);
+    expect(conjuredItem.quality).toBe(0);
+  });
+
+});
+
 describe('updating of backstage passes', () => {
   let backstagePasses = new Item('Backstage passes to a TAFKAL80ETC concert', 5, 10);
 

--- a/src/gilded_rose.spec.js
+++ b/src/gilded_rose.spec.js
@@ -1,11 +1,128 @@
 import { Item, updateQuality } from './gilded_rose';
 
-describe('`updateQuality`', () => {
-  it("Updates the Quality", () => {
-    const standardItem = new Item('Haunted Shoe', 10, 10);
-    updateQuality([standardItem]);
-    expect(standardItem.quality).toBe(9);
+// describe.skip('`updateQuality`', () => {
+//   it("Updates the Quality", () => {
+//     const standardItem = new Item('Haunted Shoe', 10, 10);
+//     updateQuality([standardItem]);
+//     expect(standardItem.quality).toBe(9);
+//   });
+
+//   it.todo('This is a good place for a good test!');
+// });
+
+
+describe('updating of general items', () => {
+  const generalItem = new Item('Haunted Shoe', 10, 10);
+  // console.log(generalItem);
+
+  afterEach(() => {
+    // updates the quality and sell_in back to original quantities
+    generalItem.sell_in = 10;
+    generalItem.quality = 10;
+    // console.log(generalItem);
   });
 
-  it.todo('This is a good place for a good test!');
+  it('decrements the sell_in by 1', () => {
+    updateQuality([generalItem]);
+    expect(generalItem.sell_in).toBe(9);
+  });
+
+  it('decrements the quality by 1', () => {
+    updateQuality([generalItem]);
+    expect(generalItem.quality).toBe(9);
+  });
+
+  it('does not decrease the quality to a negative number', () => {
+    generalItem.quality = 0;
+    updateQuality([generalItem]);
+    expect(generalItem.quality).toBe(0);
+  });
+
+  it('decreases quality twice as fast if the sell_in is less than 0', () => {
+    generalItem.sell_in = -1;
+    updateQuality([generalItem]);
+    expect(generalItem.quality).toBe(8);
+  });
+});
+
+describe('updating of aged brie', () => {
+  const agedBrie = new Item('Aged Brie', 2, 0);
+
+  afterEach(() => {
+    // updates the quality and sell_in back to original quantities
+    agedBrie.sell_in = 2;
+    agedBrie.quality = 0;
+  });
+
+  it('increments in quality by 1', () => {
+    updateQuality([agedBrie]);
+    expect(agedBrie.quality).toBe(1);
+  });
+
+  it('decrements the sell_in by 1', () => {
+    updateQuality([agedBrie]);
+    expect(agedBrie.sell_in).toBe(1);
+  });
+
+  it('does not increase the quality to more than 50', () => {
+    agedBrie.quality = 50;
+    updateQuality([agedBrie]);
+    expect(agedBrie.quality).toBe(50);
+  });
+
+});
+
+describe('updating of sulfuras', () => {
+  const sulfuras = new Item('Sulfuras, Hand of Ragnaros', 0, 80);
+
+  it('does not update sell_in', () => {
+    updateQuality([sulfuras]);
+    expect(sulfuras.sell_in).toBe(0);
+  });
+
+  it('does not update quality', () => {
+    updateQuality([sulfuras]);
+    expect(sulfuras.quality).toBe(80);
+  });
+
+});
+
+describe('updating of backstage passes', () => {
+  const backstagePasses = new Item('Backstage passes to an NSYNC concert', 15, 20);
+
+  afterEach(() => {
+    // updates the quality and sell_in back to original quantities
+    backstagePasses.sell_in = 15;
+    backstagePasses.quality = 20;
+  });
+
+  it('decrements the sell_in by 1', () => {
+    updateQuality([backstagePasses]);
+    expect(backstagePasses.sell_in).toBe(14);
+  });
+
+  it('has a quality of 0 is the sell_in is less than 0', () => {
+    backstagePasses.sell_in = -1;
+    updateQuality([backstagePasses]);
+    expect(backstagePasses.quality).toBe(0);
+  });
+
+  it('increases in quality by 3 if the sell_in is less than 6', () => {
+    backstagePasses.sell_in = 4;
+    updateQuality([backstagePasses]);
+    expect(backstagePasses.quality).toBe(23);
+  });
+
+  it('increases in quality by 2 if the sell_in is less than 11', () => {
+    backstagePasses.sell_in = 8;
+    updateQuality([backstagePasses]);
+    expect(backstagePasses.quality).toBe(22);
+  });
+
+  it('increases in quality by 1 if the sell_in is more than 10', () => {
+    backstagePasses.sell_in = 11;
+    updateQuality([backstagePasses]);
+    expect(backstagePasses.quality).toBe(21);
+  });
+
 });

--- a/src/gilded_rose.spec.js
+++ b/src/gilded_rose.spec.js
@@ -1,50 +1,5 @@
 import { Item, updateQuality } from './gilded_rose';
 
-// describe.skip('`updateQuality`', () => {
-//   it("Updates the Quality", () => {
-//     const standardItem = new Item('Haunted Shoe', 10, 10);
-//     updateQuality([standardItem]);
-//     expect(standardItem.quality).toBe(9);
-//   });
-
-//   it.todo('This is a good place for a good test!');
-// });
-
-
-describe('updating of general items', () => {
-  const generalItem = new Item('Haunted Shoe', 10, 10);
-  // console.log(generalItem);
-
-  afterEach(() => {
-    // updates the quality and sell_in back to original quantities
-    generalItem.sell_in = 10;
-    generalItem.quality = 10;
-    // console.log(generalItem);
-  });
-
-  it('decrements the sell_in by 1', () => {
-    updateQuality([generalItem]);
-    expect(generalItem.sell_in).toBe(9);
-  });
-
-  it('decrements the quality by 1', () => {
-    updateQuality([generalItem]);
-    expect(generalItem.quality).toBe(9);
-  });
-
-  it('does not decrease the quality to a negative number', () => {
-    generalItem.quality = 0;
-    updateQuality([generalItem]);
-    expect(generalItem.quality).toBe(0);
-  });
-
-  it('decreases quality twice as fast if the sell_in is less than 0', () => {
-    generalItem.sell_in = -1;
-    updateQuality([generalItem]);
-    expect(generalItem.quality).toBe(8);
-  });
-});
-
 describe('updating of aged brie', () => {
   const agedBrie = new Item('Aged Brie', 2, 0);
 
@@ -54,20 +9,26 @@ describe('updating of aged brie', () => {
     agedBrie.quality = 0;
   });
 
-  it('increments in quality by 1', () => {
+  it('increases the quality of the item by 1', () => {
     updateQuality([agedBrie]);
     expect(agedBrie.quality).toBe(1);
   });
 
-  it('decrements the sell_in by 1', () => {
-    updateQuality([agedBrie]);
-    expect(agedBrie.sell_in).toBe(1);
-  });
+  // it('decreases the sell_in of the item by 1', () => {
+  //   updateQuality([agedBrie]);
+  //   expect(agedBrie.sell_in).toBe(1);
+  // });
 
-  it('does not increase the quality to more than 50', () => {
+  it('does not increase the quality of the item to more than 50', () => {
     agedBrie.quality = 50;
     updateQuality([agedBrie]);
     expect(agedBrie.quality).toBe(50);
+  });
+
+  it('increases in quality of the item by 2 if sell_in is less than 0', () => {
+    agedBrie.sell_in = -1;
+    updateQuality([agedBrie]);
+    expect(agedBrie.quality).toBe(2);
   });
 
 });
@@ -88,41 +49,79 @@ describe('updating of sulfuras', () => {
 });
 
 describe('updating of backstage passes', () => {
-  const backstagePasses = new Item('Backstage passes to an NSYNC concert', 15, 20);
+  let backstagePasses = new Item('Backstage passes to a TAFKAL80ETC concert', 5, 10);
 
   afterEach(() => {
     // updates the quality and sell_in back to original quantities
-    backstagePasses.sell_in = 15;
-    backstagePasses.quality = 20;
+    backstagePasses.sell_in = 5;
+    backstagePasses.quality = 10;
   });
 
-  it('decrements the sell_in by 1', () => {
+  it('decreases the sell_in of the item by 1', () => {
     updateQuality([backstagePasses]);
-    expect(backstagePasses.sell_in).toBe(14);
+    expect(backstagePasses.sell_in).toBe(4);
   });
 
-  it('has a quality of 0 is the sell_in is less than 0', () => {
-    backstagePasses.sell_in = -1;
+  it('decreases the quality of the item to 0 if the sell_in is 0', () => {
+    backstagePasses.sell_in = 0;
     updateQuality([backstagePasses]);
     expect(backstagePasses.quality).toBe(0);
   });
 
-  it('increases in quality by 3 if the sell_in is less than 6', () => {
+  it('increases the quality of the item by 3 if the sell_in is 5 or less', () => {
     backstagePasses.sell_in = 4;
+    updateQuality([backstagePasses]);
+    expect(backstagePasses.quality).toBe(13);
+  });
+
+  it('increases the quality of the item by 2 if the sell_in is 10 or less', () => {
+    backstagePasses.sell_in = 8;
+    updateQuality([backstagePasses]);
+    expect(backstagePasses.quality).toBe(12);
+  });
+
+  it('increases the quality of the item by 1 if the sell_in is more than 10', () => {
+    backstagePasses.sell_in = 11;
+    updateQuality([backstagePasses]);
+    expect(backstagePasses.quality).toBe(11);
+  });
+
+  it('increases the quality of the item by 1 if the sell_in is more than 10', () => {
+    backstagePasses.quality = 20;
     updateQuality([backstagePasses]);
     expect(backstagePasses.quality).toBe(23);
   });
+});
 
-  it('increases in quality by 2 if the sell_in is less than 11', () => {
-    backstagePasses.sell_in = 8;
-    updateQuality([backstagePasses]);
-    expect(backstagePasses.quality).toBe(22);
+describe('updating of general items', () => {
+  const generalItem = new Item('Haunted Shoe', 10, 10);
+
+  afterEach(() => {
+    // updates the quality and sell_in back to original quantities
+    generalItem.sell_in = 10;
+    generalItem.quality = 10;
+    // console.log(generalItem);
   });
 
-  it('increases in quality by 1 if the sell_in is more than 10', () => {
-    backstagePasses.sell_in = 11;
-    updateQuality([backstagePasses]);
-    expect(backstagePasses.quality).toBe(21);
+  it('decreases the sell_in of the item by 1', () => {
+    updateQuality([generalItem]);
+    expect(generalItem.sell_in).toBe(9);
   });
 
+  it('decreases the quality of the item by 1', () => {
+    updateQuality([generalItem]);
+    expect(generalItem.quality).toBe(9);
+  });
+
+  it('does not decrease the quality of the item to a negative number', () => {
+    generalItem.quality = 0;
+    updateQuality([generalItem]);
+    expect(generalItem.quality).toBe(0);
+  });
+
+  it('decreases the quality of the item by 2 if the sell_in is less than 0', () => {
+    generalItem.sell_in = -1;
+    updateQuality([generalItem]);
+    expect(generalItem.quality).toBe(8);
+  });
 });


### PR DESCRIPTION
## Description
Update test coverage and add tests for conjured items

## Spec

See Issue: [27](https://sparkbox.atlassian.net/browse/FSA2021-27)

## Validation
- [ ] This PR has code changes, and our linters still pass.
- [X] This PR has new code, so new tests were added or updated, and they pass.

### To Validate

1. Make sure all PR Checks have passed.
1. Pull down all related branches.
1. Navigate to `test--add-tests-for-conjured-items`
2. Run `npm run test:coverage`
